### PR TITLE
docs(readme): add 'markdown="1"' to the header

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ Javascript assignments for a course
 
 - Boring
 - Basic javascript, html, css
-- Uses github pages
-  https://shishifubing.com/snippets-javascript-assignments
+- Uses github pages - https://shishifubing.com/snippets-javascript-assignments
 
 ## Contents
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Javascript assignments for a course
 - Boring
 - Basic javascript, html, css
 - Uses github pages
+  https://shishifubing.com/snippets-javascript-assignments
 
 ## Contents
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align="center">
+<div align="center" markdown="1">
 
 # [`snippets-javascript-assignments`][url-repo]
 


### PR DESCRIPTION
Github Pages do not render Markdown inside of a div

You can fix it by adding `markdown="1"` to a div
```html
<div align="center" markdown="1">
some text
</div>
```

https://github.com/markedjs/marked/issues/488#issuecomment-353527208

![image](https://user-images.githubusercontent.com/97828377/219856482-aeea0aa2-33e9-41ff-8a4f-75535d16730f.png)
